### PR TITLE
Windows XP SP3 compatibility patch

### DIFF
--- a/src/bits.h
+++ b/src/bits.h
@@ -743,7 +743,7 @@ struct MDBX_env {
   } me_dbgeo;      /* */
 
 #if defined(_WIN32) || defined(_WIN64)
-  SRWLOCK me_remap_guard;
+  MDBX_shlock me_remap_guard;
   /* Workaround for LockFileEx and WriteFile multithread bug */
   CRITICAL_SECTION me_windowsbug_lock;
 #else

--- a/src/lck-windows.c
+++ b/src/lck-windows.c
@@ -162,7 +162,7 @@ void mdbx_txn_unlock(MDBX_env *env) {
 #define LCK_UPPER LCK_UP_OFFSET, LCK_UP_LEN
 
 int mdbx_rdt_lock(MDBX_env *env) {
-  AcquireSRWLockShared(&env->me_remap_guard);
+  mdbx_shlock_acquireShared(&env->me_remap_guard);
   if (env->me_lfd == INVALID_HANDLE_VALUE)
     return MDBX_SUCCESS; /* readonly database in readonly filesystem */
 
@@ -178,7 +178,7 @@ void mdbx_rdt_unlock(MDBX_env *env) {
     if (!funlock(env->me_lfd, LCK_UPPER))
       mdbx_panic("%s failed: errcode %u", mdbx_func_, GetLastError());
   }
-  ReleaseSRWLockShared(&env->me_remap_guard);
+  mdbx_shlock_releaseShared(&env->me_remap_guard);
 }
 
 static int suspend_and_append(mdbx_handle_array_t **array,
@@ -573,4 +573,70 @@ int mdbx_rpid_check(MDBX_env *env, mdbx_pid_t pid) {
     /* failure */
     return rc;
   }
+}
+
+/*----------------------------------------------------------------------------*/
+/* shared lock
+   Copyright (C) 1995-2002 Brad Wilson
+*/
+
+void mdbx_shlock_init(MDBX_shlock *lck)
+{
+	lck->readerCount = lck->writerCount = 0;
+}
+
+void mdbx_shlock_acquireShared(MDBX_shlock *lck)
+{
+	while (1) {
+		//  If there's a writer already, spin without unnecessarily
+		//  interlocking the CPUs
+
+		if (lck->writerCount != 0) {
+			YieldProcessor();
+			continue;
+		}
+
+		//  Add to the readers list
+
+		_InterlockedIncrement((long*)&lck->readerCount);
+
+		//  Check for writers again (we may have been pre-empted). If
+		//  there are no writers writing or waiting, then we're done.
+
+		if (lck->writerCount == 0)
+			break;
+
+		//  Remove from the readers list, spin, try again
+
+		_InterlockedDecrement((long*)&lck->readerCount);
+		YieldProcessor();
+	}
+}
+
+void mdbx_shlock_releaseShared(MDBX_shlock *lck)
+{
+	_InterlockedDecrement((long*)&lck->readerCount);
+}
+
+void mdbx_shlock_acquireExclusive(MDBX_shlock *lck)
+{
+	//  See if we can become the writer (expensive, because it inter-
+	//  locks the CPUs, so writing should be an infrequent process)
+
+	while (_InterlockedExchange((long*)&lck->writerCount, 1) == 1) {
+		YieldProcessor();
+	}
+
+	//  Now we're the writer, but there may be outstanding readers.
+	//  Spin until there aren't any more; new readers will wait now
+	//  that we're the writer.
+
+	while (lck->readerCount != 0) {
+		YieldProcessor();
+	}
+}
+
+void mdbx_shlock_releaseExclusive(MDBX_shlock *lck)
+{
+	lck->writerCount = 0;
 }

--- a/src/mdbx.c
+++ b/src/mdbx.c
@@ -1637,7 +1637,7 @@ static int mdbx_mapresize(MDBX_env *env, const pgno_t size_pgno,
   /* Acquire guard in exclusive mode for:
    *   - to avoid collision between read and write txns around env->me_dbgeo;
    *   - to avoid attachment of new reading threads (see mdbx_rdt_lock); */
-  AcquireSRWLockExclusive(&env->me_remap_guard);
+  mdbx_shlock_acquireExclusive(&env->me_remap_guard);
   mdbx_handle_array_t *suspended = NULL;
   mdbx_handle_array_t array_onstack;
   int rc = MDBX_SUCCESS;
@@ -1712,7 +1712,7 @@ bailout:
 
 #if defined(_WIN32) || defined(_WIN64)
   int err = MDBX_SUCCESS;
-  ReleaseSRWLockExclusive(&env->me_remap_guard);
+  mdbx_shlock_releaseExclusive(&env->me_remap_guard);
   if (suspended) {
     err = mdbx_resume_threads_after_remap(suspended);
     if (suspended != &array_onstack)
@@ -4502,7 +4502,7 @@ int __cold mdbx_env_create(MDBX_env **penv) {
     goto bailout;
 
 #if defined(_WIN32) || defined(_WIN64)
-  InitializeSRWLock(&env->me_remap_guard);
+  mdbx_shlock_init(&env->me_remap_guard);
   InitializeCriticalSection(&env->me_windowsbug_lock);
 #else
   rc = mdbx_fastmutex_init(&env->me_remap_guard);

--- a/src/osal.h
+++ b/src/osal.h
@@ -522,6 +522,18 @@ void mdbx_txn_unlock(MDBX_env *env);
 int mdbx_rpid_set(MDBX_env *env);
 int mdbx_rpid_clear(MDBX_env *env);
 
+typedef struct MDBX_shlock
+{
+	__declspec(align(64)) long volatile readerCount;
+	__declspec(align(64)) long volatile writerCount;
+} MDBX_shlock;
+
+void mdbx_shlock_init(MDBX_shlock *lck);
+void mdbx_shlock_acquireShared(MDBX_shlock *lck);
+void mdbx_shlock_releaseShared(MDBX_shlock *lck);
+void mdbx_shlock_acquireExclusive(MDBX_shlock *lck);
+void mdbx_shlock_releaseExclusive(MDBX_shlock *lck);
+
 /* Checks reader by pid.
  *
  * Returns:


### PR DESCRIPTION
- all SRW* functions are replaced with the faster open source implementation of shared locks;
- bunch of functions missing in XP are called dynamically